### PR TITLE
Change example to include Heroku PORT practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Redirect users to the SSL version of your app. For ExpressJS running on Heroku
       res.send('hello world');
     });
 
-    app.listen(3000);
+    app.listen(process.env.PORT || 3000);
 
 ### Environments
 


### PR DESCRIPTION
When trying to set this up, it could be confusing that this doesn't reference the practice of specifying process.env.PORT. Many developers might not realize the need to bind to process.env.PORT and if they follow the instructions as specified, they may end up with an application that isn't working.

This updates the example to follow those practices by specifying `process.env.PORT || 3000`.